### PR TITLE
Remove unused imports

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,4 @@
-import os, sys
-import argparse
-import math, random
-import torch
-import tqdm
+import os
 
 PARAMS_CONFIG = {
     # env-specific

--- a/custom_functions.py
+++ b/custom_functions.py
@@ -1,6 +1,3 @@
-import os, sys
-import argparse
-import math, random
 import torch
 import fmoe_cuda
 from torch.autograd import Function

--- a/custom_gates.py
+++ b/custom_gates.py
@@ -1,12 +1,7 @@
-import os, sys
-import argparse
-import math, random
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import pdb
-import numpy as np
 from fmoe.gates.base_gate import BaseGate
 
 __all__ = [

--- a/custom_layers.py
+++ b/custom_layers.py
@@ -1,6 +1,4 @@
-import os, sys
-import argparse
-import math, random
+import math
 import torch
 import torch.nn as nn
 import tree

--- a/custom_layers_opt.py
+++ b/custom_layers_opt.py
@@ -3,7 +3,6 @@ FMoE core layer
 """
 
 import tree
-import os
 import torch
 import torch.nn as nn
 

--- a/custom_transformer.py
+++ b/custom_transformer.py
@@ -1,6 +1,3 @@
-import os, sys
-import argparse
-import math, random
 import torch
 import torch.nn as nn
 from custom_layers import FMoE

--- a/custom_utils.py
+++ b/custom_utils.py
@@ -1,7 +1,3 @@
-import os, sys
-import argparse
-import math, random
-import torch
 import torch.distributed as dist
 
 

--- a/data.py
+++ b/data.py
@@ -1,8 +1,5 @@
-import os, sys
-import argparse
-import math, random
+import os
 import torch
-import tqdm
 
 
 def _tokenize(text_path, dictionary_to_update):

--- a/fastermoe/config.py
+++ b/fastermoe/config.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 
 def float_from_env(key, default=-1):
     if key in os.environ:

--- a/fastermoe/expert_utils.py
+++ b/fastermoe/expert_utils.py
@@ -1,4 +1,3 @@
-import os, sys
 import torch
 
 def get_expert_param_size(e):

--- a/fastermoe/schedule.py
+++ b/fastermoe/schedule.py
@@ -1,8 +1,7 @@
-import os, sys
 import torch
 from torch.autograd.function import Function
 
-from fmoe.functions import prepare_forward, ensure_comm
+from fmoe.functions import prepare_forward
 from fmoe.functions import _local_scatter, _local_gather 
 import fmoe_cuda as fmoe_native
 from fmoe.fastermoe import expert_utils

--- a/fastermoe/shadow_policy.py
+++ b/fastermoe/shadow_policy.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 import torch
 import torch.distributed as dist
 

--- a/finetune_data.py
+++ b/finetune_data.py
@@ -1,13 +1,8 @@
-import os, sys
+import os
 import glob
-import pdb
-from collections import Counter, OrderedDict
 import numpy as np
 import torch
-from torch.utils.data import Dataset, DataLoader
 from vocabulary import Vocab
-import torch.nn.functional as F
-from torch.nn.utils.rnn import pad_sequence
 import pytreebank
 
 

--- a/finetune_models.py
+++ b/finetune_models.py
@@ -1,10 +1,7 @@
-import os, sys
-import argparse
-import math, random
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import tqdm
 
 from custom_transformer import FMoETransformerMLP, FMoETransformerMLPOpt
 from custom_gates import *

--- a/finetune_train.py
+++ b/finetune_train.py
@@ -1,13 +1,9 @@
-import os, sys
 import warnings
 
 warnings.filterwarnings("ignore")
 
-import argparse
-import math, random
 import torch
 import time
-import pdb
 from config import PARAMS_CONFIG
 
 from finetune_data import get_lm_corpus

--- a/finetune_trainer.py
+++ b/finetune_trainer.py
@@ -1,9 +1,6 @@
-import os, sys
-import argparse
 import math, random
 import torch
 import tqdm
-import pdb
 import torch.nn as nn
 from custom_gates import *
 

--- a/gates/base_gate.py
+++ b/gates/base_gate.py
@@ -1,4 +1,3 @@
-import os, sys
 import torch.nn as nn
 
 class BaseGate(nn.Module):

--- a/gates/faster_gate.py
+++ b/gates/faster_gate.py
@@ -1,12 +1,9 @@
-import os, sys
+import os
 from .naive_gate import NaiveGate
 
 import os
-import sys
 import torch
 import torch.nn.functional as F
-from .utils import limit_by_capacity
-import fmoe_cuda
 from fmoe.functions import count_by_gate
 
 nw_per_node = 8

--- a/gates/gshard_gate.py
+++ b/gates/gshard_gate.py
@@ -1,4 +1,3 @@
-import os, sys
 import math
 import torch
 import torch.nn.functional as F

--- a/gates/naive_gate.py
+++ b/gates/naive_gate.py
@@ -1,4 +1,3 @@
-import os, sys
 from .base_gate import BaseGate
 
 import torch

--- a/gates/noisy_gate.py
+++ b/gates/noisy_gate.py
@@ -1,9 +1,7 @@
-import os, sys
 from .base_gate import BaseGate
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.distributions.normal import Normal
 import math
 

--- a/gates/swipe_gate.py
+++ b/gates/swipe_gate.py
@@ -1,12 +1,7 @@
-import os, sys
-import math
 import torch
-import torch.distributed as dist
-import torch.nn as nn
 import torch.nn.functional as F
 from .naive_gate import NaiveGate
 
-from fmoe.functions import count_by_gate
 import fmoe_cuda as fmoe_native
 
 class SwipeGate(NaiveGate):

--- a/gates/switch_gate.py
+++ b/gates/switch_gate.py
@@ -1,7 +1,5 @@
-import os, sys
 import math
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 from .naive_gate import NaiveGate
 from .utils import limit_by_capacity

--- a/gates/utils.py
+++ b/gates/utils.py
@@ -1,4 +1,3 @@
-import os, sys
 import torch
 from fmoe.functions import count_by_gate
 import fmoe_cuda as fmoe_native

--- a/gates/zero_gate.py
+++ b/gates/zero_gate.py
@@ -1,9 +1,6 @@
-import os, sys
 from .base_gate import BaseGate
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 
 class ZeroGate(BaseGate):
     r"""

--- a/models.py
+++ b/models.py
@@ -1,14 +1,10 @@
-import os, sys
-import argparse
-import math, random
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import tqdm
 
 from custom_transformer import FMoETransformerMLP, FMoETransformerMLPOpt
 from custom_gates import *
-import cmath
 
 
 # Size notations:

--- a/train.py
+++ b/train.py
@@ -1,10 +1,8 @@
-import os, sys
 import warnings
 
 warnings.filterwarnings("ignore")
 
-import argparse
-import math, random
+import math
 import torch
 import time
 
@@ -14,7 +12,6 @@ from models import TransformerSeq
 from trainer import train_iteration, full_eval
 import datetime
 import wandb
-import os
 from utils import (
     get_params,
     set_up_env,

--- a/trainer.py
+++ b/trainer.py
@@ -1,5 +1,3 @@
-import os, sys
-import argparse
 import math, random
 import torch
 import tqdm

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,9 @@
-import os, sys
+import os
 import argparse
 import math, random
 import functools
 import os, shutil
 import torch
-import tqdm
 from models import CustomizedMoEPositionwiseFFOpt
 
 

--- a/vocabulary.py
+++ b/vocabulary.py
@@ -1,11 +1,8 @@
 import os
-import pdb
 import csv
 import json
 import torch
 from collections import Counter, OrderedDict
-import torch.nn.functional as F
-from torch.nn.utils.rnn import pad_sequence
 
 
 class Vocab(object):


### PR DESCRIPTION
Change generated using [ruff](https://docs.astral.sh/ruff/) via:

```
python -m ruff check --select=F401 --fix
```

> [!Note]
> I manually skimmed and verified that these changes look reasonable, but I did not verify the code correctness as I did not run it, and this repo has no automated tests, so it's not possible to easily verify it. Please review this change carefully.

Also, in some cases, there is some commented-out code that may use these imports, but commented-out code is not a good pattern, and should probably be deleted, or moved into a separate file, or moved into documentation since it's not used, and cannot be tested, so it's unclear if it would even work if uncommented.