### PR TITLE
Use `==` for literal comparisons instead of `is`

### DIFF
--- a/finetune_models.py
+++ b/finetune_models.py
@@ -309,7 +309,7 @@ class TransformerSeqLayer(nn.Module):
 
         self.attn = (
             MultiHeadSeqAttention(hidden_size=hidden_size, dropout=dropout, **kargs)
-            if s is "s"
+            if s == "s"
             else None
         )
         if optimal_policy:
@@ -328,7 +328,7 @@ class TransformerSeqLayer(nn.Module):
                     combine_gate=combine_gate,
                     opt_loss=opt_loss,
                 )
-                if g is "g"
+                if g == "g"
                 else None
             )
         else:
@@ -340,7 +340,7 @@ class TransformerSeqLayer(nn.Module):
                     dropout=dropout,
                     moe_top_k=moe_top_k,
                 )
-                if g is "g"
+                if g == "g"
                 else None
             )
 
@@ -350,7 +350,7 @@ class TransformerSeqLayer(nn.Module):
                 inner_hidden_size=inner_hidden_size,
                 dropout=dropout,
             )
-            if f is "f"
+            if f == "f"
             else None
         )
         self.norm1 = nn.LayerNorm(hidden_size)

--- a/models.py
+++ b/models.py
@@ -468,7 +468,7 @@ class TransformerSeqLayer(nn.Module):
 
         self.attn = (
             MultiHeadSeqAttention(hidden_size=hidden_size, dropout=dropout, **kargs)
-            if s is "s"
+            if s == "s"
             else None
         )
         if optimal_policy:
@@ -487,7 +487,7 @@ class TransformerSeqLayer(nn.Module):
                     combine_gate=combine_gate,
                     opt_loss=opt_loss,
                 )
-                if g is "g"
+                if g == "g"
                 else None
             )
         else:
@@ -499,7 +499,7 @@ class TransformerSeqLayer(nn.Module):
                     dropout=dropout,
                     moe_top_k=moe_top_k,
                 )
-                if g is "g"
+                if g == "g"
                 else 
                 CustomizedMoEPositionwiseFFMoM(
                     gate,
@@ -514,7 +514,7 @@ class TransformerSeqLayer(nn.Module):
                     beta2=beta2,
                     layerth=layerth,
                 )
-                if g is "m"
+                if g == "m"
                 else 
                 CustomizedMoEPositionwiseFFAdam(
                     gate,
@@ -529,7 +529,7 @@ class TransformerSeqLayer(nn.Module):
                     beta2=beta2,
                     layerth=layerth,
                 )
-                if g is "a"
+                if g == "a"
                 else None
             )
 
@@ -539,7 +539,7 @@ class TransformerSeqLayer(nn.Module):
                 inner_hidden_size=inner_hidden_size,
                 dropout=dropout,
             )
-            if f is "f"
+            if f == "f"
             else None
         )
         self.norm1 = nn.LayerNorm(hidden_size)


### PR DESCRIPTION
Fixes [these warnings from Pytype][1]:

```
.../MomentumSMoE/finetune_models.py:312: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if s is "s"
.../MomentumSMoE/finetune_models.py:331: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "g"
.../MomentumSMoE/finetune_models.py:343: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "g"
.../MomentumSMoE/finetune_models.py:353: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if f is "f"
.../MomentumSMoE/models.py:471: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if s is "s"
.../MomentumSMoE/models.py:490: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "g"
.../MomentumSMoE/models.py:502: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "g"
.../MomentumSMoE/models.py:517: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "m"
.../MomentumSMoE/models.py:532: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if g is "a"
.../MomentumSMoE/models.py:542: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if f is "f"
```

[1]: https://github.com/rachtsy/MomentumSMoE/actions/runs/14545826726/job/40811129439#step:9:12