### PR TITLE
Uncomment `torch` and `numpy`; add `wandb`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-# torch==2.2.0 
-# numpy
+torch == 2.2.0
+numpy
 ninja
 dm-tree
 tqdm
-torchmetrics==1.3.1
+torchmetrics == 1.3.1
+wandb


### PR DESCRIPTION
All of these modules are directly used in the code, so anyone using them in a virtual environment would need to install them, and this is impacting the type checking tests as these libraries are missing, which is throwing errors during testing.

Also added spaces around `==` for readability as that's allowed in this file.